### PR TITLE
Manual installation falsely talked about *.app download

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@
 
 ### Manual
 
-1. Download the *.app* from the [release page](https://github.com/soerenkampschroer/plex-to-vlc/releases/latest).
-2. Move it to `/Applications`
-3. Download the Native Messaging configuration file for Chrome [here](chrome-extension/com.soerenkampschroer.plextovlc.json).
+1. Download the *.dmg* from the [release page](https://github.com/soerenkampschroer/plex-to-vlc/releases/latest).
+2. Double click the *.dmg*: This mounts the disk image and opens it in a Finder window.
+3. Drag and drop the contained `plex-to-vlc.app` to `/Applications`
+4. Download the Native Messaging configuration file for Chrome [here](chrome-extension/com.soerenkampschroer.plextovlc.json).
     Move it to `~/Library/Application\ Support/Google/Chrome/NativeMessagingHosts/`.
   **Note:** If you didn't move the App to `/Applications` in step 2, you need to update the path in the json file.
 


### PR DESCRIPTION
- In reality it is a *.app (app bundle) within a *.dmg (Disk Image)
- Updated README.md accordingly